### PR TITLE
Pass through non-JSON verbatim, like pino-pretty

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,11 @@ var levels = {
 }
 
 var logLevelTransformer = through.obj(function (chunk, enc, cb) {
+  if (typeof chunk === 'string') {
+    console.log(chunk);
+    cb();
+    return;
+  }
 
   if (chunk.level) {
     chunk = Object.assign({},chunk,{
@@ -32,4 +37,18 @@ var logLevelTransformer = through.obj(function (chunk, enc, cb) {
   cb()
 })
 
-pump(process.stdin, split(JSON.parse), logLevelTransformer)
+/**
+ * Parse as JSON if it is JSON, otherwise just return it.
+ */
+function tryParseJSON(s) {
+  try {
+    return JSON.parse(s);
+  } catch (e) {
+    if (e.name === 'SyntaxError') {
+      return s;
+    }
+    throw e;
+  }
+}
+
+pump(process.stdin, split(tryParseJSON), logLevelTransformer)


### PR DESCRIPTION
We're running into trouble because we need to keep access to raw, non-JSON console.log on Heroku, for custom Librato metrics (which also source from the logs).

This PR makes pino-logdna-formatter behave like pino-pretty (the official pinojs pretty printer): if a line is not JSON, just pass it through without further consideration.

Cheers